### PR TITLE
Usability Tweaks for Consuming the Template

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -28,6 +28,19 @@ this, edit the following line:
 DOCUMENT_BASE_NAME: ${{ github.event.repository.name }}
 ```
 
+### [Create From Template](./create-from-template.yml)
+
+[create-from-template.yml](./create-from-template.yml) is designed to run only
+once, when a new repository is created from the template. On the first `push`
+event to a non-template repository, it will checkout the repo, delete itself,
+and amend the initial commit to conform to the
+[Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)
+specification.
+
+> [!TIP]
+> Remove this section after creating your repo from this template, as the
+> workflow will be deleted.
+
 ### [Fast Forward](./fast-forward.yml)
 
 A workflow that allows using the `/fast-forward` command to complete a PR, and

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -10,7 +10,7 @@ build a LaTeX document, and upload the resulting PDF as an artifact.
 
 ### [Build Release](./build-release.yml)
 
-[build-release.ym](./build-release.yml) contains the main build workflow for
+[build-release.yml](./build-release.yml) contains the main build workflow for
 this repo. It will:
 
 - Automatically generate a changelog and bump the version number, based on new

--- a/.github/workflows/create-from-template.yml
+++ b/.github/workflows/create-from-template.yml
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Nathaniel Struselis
+#
+# GitHub Actions workflow to amend the initial commit so that it conforms to the
+# conventional commits specification when consuming this template.
+
+name: "Create Repository From Template"
+
+# This workflow runs on any push, since the default branch name is configurable
+# by the user. Creating a repository from a template will cause the "push"
+# event.
+on:
+  push:
+
+# Write permission is needed to amend the initial commit and push to the remote.
+permissions:
+  contents: write
+
+jobs:
+  amend-initial-commit:
+    name: "Amend Initial Commit"
+    # This job only runs if the repository is not a template, to avoid
+    # altering the template repository itself.
+    if: ${{ !github.event.repository.is_template }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v5
+        with:
+          # Ensure the initial commit is available to amend.
+          fetch-depth: 0
+
+      # Remove this workflow file from the new repository.
+      - name: "Remove Template Specific Files"
+        run: |
+          rm -f "./.github/workflows/create-from-template.yml"
+
+      # Amend the initial commit with the removed workflow, and change the
+      # commit message to conform to the conventional commits specification.
+      - name: "Update Initial Commit"
+        run: |
+          # Configure the git user to the GitHub Actions actor.
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+
+          # Add the changes and amend the initial commit, updating the commit
+          # message.
+          git add .
+          git commit --amend -m "chore: initial commit"
+          git push --force-with-lease

--- a/README.md
+++ b/README.md
@@ -210,6 +210,12 @@ to delete a line from the workflow, or create a
 For more information, see
 [the workflow README.md](./.github/workflows/README.md#fast-forward).
 
+The
+[create-from-template.yml section](./.github/workflows/README.md#create-from-template)
+of the [workflows README.md](./.github/workflows/README.md) can be deleted after
+creating a repository from this template, as the workflow will run and delete
+itself.
+
 ## License
 
 The contents of this repository, including the basic LaTeX template, GitHub

--- a/README.md
+++ b/README.md
@@ -214,7 +214,11 @@ For more information, see
 
 The contents of this repository, including the basic LaTeX template, GitHub
 Actions, and basic documentation, are licensed under the
-[MIT license](https://mit-license.org/) (see [LICENSE](./LICENSE)).
+[MIT license](https://mit-license.org/) (see [LICENSE](./LICENSE)):
+
+```
+SPDX-License-Identifier: MIT
+```
 
 ### What This Means For You
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -24,7 +24,7 @@ body = """
     {% endfor %}
 {% endfor -%}
 {%- if github.contributors | filter(attribute="is_first_time", value=true) -%}
-    ## New Contributors
+    ### New Contributors
 
     {% for contributor in github.contributors | filter(attribute="is_first_time", value=true) -%}
         - @{{ contributor.username }} made their first contribution

--- a/front_matter/document_revision.tex
+++ b/front_matter/document_revision.tex
@@ -14,5 +14,5 @@
     % preamble/authors.tex to link the initials here to a name. Without doing
     % this, only the initials will appear for the document authors.
     % Example entry for NS in preamble/authors.tex:
-    \vhEntry{0.1.0}{2025/10/15}{NS}{Initial template version}
+    \vhEntry{0.1.1}{2025/10/15}{NS}{Initial template version}
 \end{versionhistory}


### PR DESCRIPTION
This PR improves some of the issues that I noticed when using the template for the first time:

- #10
- #12 
- #13 

The main component of this PR is a new workflow which will only run in repos consuming this template. It's only purpose is to amend the "Initial commit" in the repo to make it conform to the [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0), without the need to manually rebase the initial commit.

I've chosen the following as the commit message: `chore: initial commit`, as I'm not sure the initial commit can be considered a `feat`, since it's not got any changes specific to the new repo.

The workflow will then delete itself, as it will not be needed again in the new repo.