### PR TITLE
Fix initial commit detection

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0  # Fetch all history for accurate commit count.
 
       # Evaluate whether the workflow should run or not.
       - name: Evaluate Run Conditions


### PR DESCRIPTION
This PR updates the `build-release.yml` workflow to fetch the full repo history when checking for the initial commit, to hopefully fix the commit count detection.